### PR TITLE
fix: typo in manifest causes healthcheck to fail

### DIFF
--- a/copilot/api/manifest.yml
+++ b/copilot/api/manifest.yml
@@ -18,7 +18,7 @@ http:
   # To match all requests you can use the "/" path. 
   path: '/'
   # You can specify a custom health check path. The default is "/"
-  healthcheck: '/_healtcheck'
+  healthcheck: '/_healthcheck'
 
 # Number of CPU units for the task.
 cpu: 256


### PR DESCRIPTION
Typo in the manifest for api service causes its healthchecks to fail which kills tasks continually:

![Screenshot 2020-10-29 at 11 37 19](https://user-images.githubusercontent.com/7933071/97557539-2d17d180-19db-11eb-8e09-4ee85ffebf15.png)
